### PR TITLE
[AS-84] Sidebar Layout: Add min-width based in content

### DIFF
--- a/src/components/Layouts/MainSidebarLayout/main-sidebar-layout.scss
+++ b/src/components/Layouts/MainSidebarLayout/main-sidebar-layout.scss
@@ -1,4 +1,5 @@
 .main-sidebar-layout {
+  min-width: fit-content;
   padding: 24px;
   box-shadow: 5px 0 18px 0 rgb(0 0 0 / 4%);
   background-color: $colors-white-10;


### PR DESCRIPTION
After checking the behaviour of the sidebar we have detected a problem.

Sometimes the sidebar do scroll on the x-axis, and this behaviour is not as expected.

![image](https://github.com/user-attachments/assets/72f26d04-1184-484c-8752-2a69b72b2af7)

This occurs when we set overflow-y: auto and it is a flex-item.

To fix this we have set the min-width based on the content
